### PR TITLE
Fix so a default PriorityClass can be used

### DIFF
--- a/api/v1alpha1/nodescalingwatermark_types.go
+++ b/api/v1alpha1/nodescalingwatermark_types.go
@@ -55,10 +55,10 @@ type NodeScalingWatermarkSpec struct {
 	// +kubebuilder:default:="k8s.gcr.io/pause"
 	PausePodImage string `json:"pausePodImage"`
 
-	// Priority is the priority assigned to the pause pods, if not set it will be default to 0
+	// PriorityClassName is the priorityClassName assigned to the pause pods, if not set it will be default to low-priority
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:=0
-	Priority int `json:"priority"`
+	// +kubebuilder:default:=low-priority
+	PriorityClassName string `json:"priorityClassName"`
 }
 
 // NodeScalingWatermarkStatus defines the observed state of NodeScalingWatermark

--- a/api/v1alpha1/nodescalingwatermark_types.go
+++ b/api/v1alpha1/nodescalingwatermark_types.go
@@ -55,9 +55,9 @@ type NodeScalingWatermarkSpec struct {
 	// +kubebuilder:default:="k8s.gcr.io/pause"
 	PausePodImage string `json:"pausePodImage"`
 
-	// PriorityClassName is the priorityClassName assigned to the pause pods, if not set it will be default to low-priority
+	// PriorityClassName is the priorityClassName assigned to the pause pods, if not set it will be default to proactive-node-autoscaling-pods
 	// +kubebuilder:validation:Optional
-	// +kubebuilder:default:=low-priority
+	// +kubebuilder:default:=proactive-node-autoscaling-pods
 	PriorityClassName string `json:"priorityClassName"`
 }
 

--- a/config/crd/bases/redhatcop.redhat.io_nodescalingwatermarks.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_nodescalingwatermarks.yaml
@@ -62,11 +62,12 @@ spec:
                   watermark, smaller pods will distributed better but consume slightly
                   more resources. Tuning may be required to find the optimal size.
                 type: object
-              priority:
-                default: 0
-                description: Priority is the priority assigned to the pause pods,
-                  if not set it will be default to 0
-                type: integer
+              priorityClassName:
+                default: low-priority
+                description: PriorityClassName is the priorityClassName assigned to the 
+                pause pods, if not set it will be default to 'low-priority'. You may 
+                have to create this class first and set the priority to 0.
+                type: string
               tolerations:
                 items:
                   description: The pod this Toleration is attached to tolerates any

--- a/config/crd/bases/redhatcop.redhat.io_nodescalingwatermarks.yaml
+++ b/config/crd/bases/redhatcop.redhat.io_nodescalingwatermarks.yaml
@@ -63,10 +63,9 @@ spec:
                   more resources. Tuning may be required to find the optimal size.
                 type: object
               priorityClassName:
-                default: low-priority
-                description: PriorityClassName is the priorityClassName assigned to the 
-                pause pods, if not set it will be default to 'low-priority'. You may 
-                have to create this class first and set the priority to 0.
+                default: proactive-node-autoscaling-pods
+                description: PriorityClassName is the priorityClassName assigned to
+                  the pause pods, if not set it will be default to proactive-node-autoscaling-pods
                 type: string
               tolerations:
                 items:

--- a/config/manifests/bases/proactive-node-scaling-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/proactive-node-scaling-operator.clusterserviceversion.yaml
@@ -33,16 +33,18 @@ spec:
 
     Essentially this operator allows you to trade wasted resources for faster response time.
 
-    In order for this operator to work correctly [pod priorities](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) must be defined. Here is an example of how to do so:
+    In order for this operator to work correctly [pod priorities](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) must be defined. The default name for the priority class used by this operator is "proactive-node-autoscaling-pods" and it should have the lowest possible priority, 0. To ensure your regular workloads get a normal priority you should also define a PriorityClass for those with a higher priority than 0 and set globalDefault to true.
+
+    For example:
 
     ```yaml
     apiVersion: scheduling.k8s.io/v1
     kind: PriorityClass
     metadata:
-      name: low-priority
+      name: proactive-node-autoscaling-pods
     value: 0
     globalDefault: false
-    description: "This priority class is is the low-priority class for Proactive Node Scaling."
+    description: "This priority class is the priority class used for Proactive Node Scaling Pods."
     ---
     apiVersion: scheduling.k8s.io/v1
     kind: PriorityClass
@@ -52,8 +54,6 @@ spec:
     globalDefault: true
     description: "This priority classis the cluster default and should be used for normal workloads."
     ```
-
-    The low-priority pods scheduled by this operator always have priority 0, so they should always have lower priority than anything else.
 
     Also for this operator to work the [cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) must be active, see OpenShift instructions [here](https://docs.openshift.com/container-platform/4.6/machine_management/applying-autoscaling.html) on how to turn it on.
 
@@ -65,7 +65,7 @@ spec:
     metadata:
       name: us-west-2a
     spec:
-      priorityClassName: low-priority
+      priorityClassName: proactive-node-autoscaling-pods
       watermarkPercentage: 20
       nodeSelector:
         topology.kubernetes.io/zone: us-west-2a

--- a/config/manifests/bases/proactive-node-scaling-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/proactive-node-scaling-operator.clusterserviceversion.yaml
@@ -39,13 +39,21 @@ spec:
     apiVersion: scheduling.k8s.io/v1
     kind: PriorityClass
     metadata:
+      name: low-priority
+    value: 0
+    globalDefault: false
+    description: "This priority class is is the low-priority class for Proactive Node Scaling."
+    ---
+    apiVersion: scheduling.k8s.io/v1
+    kind: PriorityClass
+    metadata:
       name: normal-workload
     value: 1000
     globalDefault: true
     description: "This priority classis the cluster default and should be used for normal workloads."
     ```
 
-    The low priority pods scheduled by this operator always have priority 0, so they should always have lower priority than anything else.
+    The low-priority pods scheduled by this operator always have priority 0, so they should always have lower priority than anything else.
 
     Also for this operator to work the [cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) must be active, see OpenShift instructions [here](https://docs.openshift.com/container-platform/4.6/machine_management/applying-autoscaling.html) on how to turn it on.
 
@@ -57,6 +65,7 @@ spec:
     metadata:
       name: us-west-2a
     spec:
+      priorityClassName: low-priority
       watermarkPercentage: 20
       nodeSelector:
         topology.kubernetes.io/zone: us-west-2a

--- a/config/templates/watermarkDeploymentTemplate.yaml
+++ b/config/templates/watermarkDeploymentTemplate.yaml
@@ -28,7 +28,7 @@ spec:
       tolerations: 
         {{- toYaml . | nindent 8 }}
       {{- end }}        
-      priority: {{ .NodeScalingWatermark.Spec.Priority }}
+      priorityClassName: {{ .NodeScalingWatermark.Spec.PriorityClassName }}
       automountServiceAccountToken: false  
       containers:
       - name: pause

--- a/readme.md
+++ b/readme.md
@@ -14,16 +14,18 @@ The Proactive Node Scaling Operator improves the user experience by allocating l
 
 Essentially this operator allows you to trade wasted resources for faster response time.
 
-In order for this operator to work correctly [pod priorities](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) must be defined. Here is an example of how to do so:
+In order for this operator to work correctly [pod priorities](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/) must be defined. The default name for the priority class used by this operator is "proactive-node-autoscaling-pods" and it should have the lowest possible priority, 0. To ensure your regular workloads get a normal priority you should also define a PriorityClass for those and set globalDefault to true.
+
+For example:
 
 ```yaml
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: low-priority
+  name: proactive-node-autoscaling-pods
 value: 0
 globalDefault: false
-description: "This priority class is is the low-priority class for Proactive Node Scaling."
+description: "This priority class is is the Priority class for Proactive Node Scaling."
 ---
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
@@ -33,8 +35,6 @@ value: 1000
 globalDefault: true
 description: "This priority classis the cluster default and should be used for normal workloads."
 ```
-
-The low-priority pods scheduled by this operator always have priority 0, so they should always have lower priority than anything else.
 
 Also for this operator to work the [cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) must be active, see OpenShift instructions [here](https://docs.openshift.com/container-platform/4.6/machine_management/applying-autoscaling.html) on how to turn it on.
 
@@ -46,7 +46,7 @@ kind: NodeScalingWatermark
 metadata:
   name: us-west-2a
 spec:
-  priorityClassName: low-priority
+  priorityClassName: proactive-node-autoscaling-pods
   watermarkPercentage: 20
   nodeSelector:
     topology.kubernetes.io/zone: us-west-2a

--- a/readme.md
+++ b/readme.md
@@ -20,14 +20,21 @@ In order for this operator to work correctly [pod priorities](https://kubernetes
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
+  name: low-priority
+value: 0
+globalDefault: false
+description: "This priority class is is the low-priority class for Proactive Node Scaling."
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
   name: normal-workload
 value: 1000
 globalDefault: true
 description: "This priority classis the cluster default and should be used for normal workloads."
-priority: 0
 ```
 
-The low priority pods scheduled by this operator will have the priority defined in the `priority` field (0 by default). The sleected prioorty should be very low so to be lower than anything else running in the cluster.
+The low-priority pods scheduled by this operator always have priority 0, so they should always have lower priority than anything else.
 
 Also for this operator to work the [cluster autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) must be active, see OpenShift instructions [here](https://docs.openshift.com/container-platform/4.6/machine_management/applying-autoscaling.html) on how to turn it on.
 
@@ -39,6 +46,7 @@ kind: NodeScalingWatermark
 metadata:
   name: us-west-2a
 spec:
+  priorityClassName: low-priority
   watermarkPercentage: 20
   nodeSelector:
     topology.kubernetes.io/zone: us-west-2a


### PR DESCRIPTION
Currently the operator can not be used when setting a default PriorityClass for your regular workloads.
If your "normal workloads" have a priority of for example 1000 and you set this to globalDefault: true the cluster expects you to use a priorityClassName for priority. The integer "priority" value is not allowed. This happens because the global default uses the priorityClassName which you can override if you provide it in the pod spec.
If you don't, the following appears:
_the integer value of priority (0) must not be provided in pod spec; priority admission controller computed 1000 from the given PriorityClass name_

Because the "low-priority" pods have a fixed priority of 0 they will stay pending and never get scheduled with above error message. Changing it to priorityClassName: low-priority fixes this and allows the pods to be scheduled.